### PR TITLE
Make Environment Parametrizable Through Initial Configuration

### DIFF
--- a/lib/constants/environments.js
+++ b/lib/constants/environments.js
@@ -1,0 +1,11 @@
+export const SANDBOX = 'sandbox'
+export const PRODUCTION = 'production'
+
+export const ENVIRONMENTS_CONFIG = {
+  [SANDBOX]: {
+    basePath: 'sandbox-api.veem.com',
+  },
+  [PRODUCTION]: {
+    basePath: 'api.veem.com',
+  },
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
 import Client from './client'
 import merge from 'lodash/merge'
+import { SANDBOX } from 'constants/environments'
 
 const defaultConfiguration = {
   type: 'oauth2',
   accessToken: null,
+  environment: SANDBOX,
 }
 
 class VeemSDK {

--- a/lib/utils/api-client.js
+++ b/lib/utils/api-client.js
@@ -3,6 +3,7 @@ import uniqueId from 'lodash/uniqueId'
 import isFile from './is-file'
 import buildUrl from './build-url'
 import { GET } from 'constants/http-methods'
+import { SANDBOX, ENVIRONMENTS_CONFIG } from 'constants/environments'
 
 import {
   JSON as CONTENT_TYPE_JSON,
@@ -14,13 +15,7 @@ import {
   OCTET_STREAM as ACCEPTS_OCTET_STREAM,
 } from 'constants/accepts'
 
-const DEFAULT_ENVIRONMENT = 'sandbox'
-
-const ENVIRONMENT_CONFIG = {
-  sandbox: {
-    basePath: 'sandbox-api.veem.com',
-  },
-}
+const DEFAULT_ENVIRONMENT = SANDBOX
 
 const DEFAULT_REQUEST_HEADER_OPTIONS = {
   Accept: ACCEPTS_JSON,
@@ -29,7 +24,7 @@ const DEFAULT_REQUEST_HEADER_OPTIONS = {
 
 class ApiClient {
   constructor (environment = DEFAULT_ENVIRONMENT) {
-    const environmentConfig = ENVIRONMENT_CONFIG[environment] || ENVIRONMENT_CONFIG[DEFAULT_ENVIRONMENT]
+    const environmentConfig = ENVIRONMENTS_CONFIG[environment] || ENVIRONMENTS_CONFIG[DEFAULT_ENVIRONMENT]
 
     this.basePath = environmentConfig.basePath
     this.accessToken = null


### PR DESCRIPTION
**Description**
Make API client configurable as to which domain to hit, based on the `environment` value (`sandbox` or `production`) passed thru at initialization time.

**Note**
I kept the environment values as lowercase as the users will not be utilizing our constants, therefore I'm suggesting it may be more intuitive and common for them to define a lowercase environment value.