### PR TITLE
Conditionally Include Authorization Header Option

### DIFF
--- a/lib/utils/apiClient.js
+++ b/lib/utils/apiClient.js
@@ -1,5 +1,6 @@
 import superagent from 'superagent'
 import uniqueId from 'lodash/uniqueId'
+import set from 'lodash/set'
 import isFile from './isFile'
 import buildUrl from './buildUrl'
 import { GET } from 'constants/httpMethods'
@@ -50,10 +51,9 @@ class ApiClient {
         },
         DEFAULT_REQUEST_HEADER_OPTIONS,
         requestHeaderOptions,
-        {
-          Authorization: `Bearer ${this.accessToken}`,
-        }
       )
+
+      this.accessToken && set(computedRequestHeaderOptions, 'Authorization', `Bearer ${this.accessToken}`)
 
       const isMultipartFormData = computedRequestHeaderOptions['Content-Type'] === CONTENT_TYPE_FORM_DATA
       const acceptsStream = computedRequestHeaderOptions['Accept'] === ACCEPTS_OCTET_STREAM


### PR DESCRIPTION
**Description**
Only include `Authorization` header if `accessToken` is defined.

**Sanity Check**
In our `/node` sandbox file, try initializing our API client **without** an access token, calling the public EP of country currency mapping. You should no longer get an error:

```
const {
  metadata,
  payment,
  invoice,
  contact,
  customer,
  exchangeRate,
  attachment,
  webhook,
} = new VeemSDK({})

metadata.getCountryCurrencyMap(null, callback)
```