### PR TITLE
Fixes `fs` Invocation in Tests

### DIFF
--- a/e2e/__tests__/Attachment.spec.js
+++ b/e2e/__tests__/Attachment.spec.js
@@ -5,6 +5,7 @@ import fs from 'fs'
 import { spy } from 'sinon'
 import { file } from 'chai-files'
 import rimraf from 'rimraf'
+import noop from 'lodash/noop'
 
 const TEMP_ASSETS_DIRECTORY = `${__dirname}/.tmp`
 
@@ -12,7 +13,7 @@ describe('attachment', () => {
   const veemSDK = new VeemSDK(CONFIG)
 
   beforeAll(async () => {
-    await fs.mkdir(TEMP_ASSETS_DIRECTORY, { recursive: true })
+    await fs.mkdir(TEMP_ASSETS_DIRECTORY, { recursive: true }, noop)
   })
 
   afterAll(() => {

--- a/e2e/__tests__/Attachment.spec.js
+++ b/e2e/__tests__/Attachment.spec.js
@@ -5,15 +5,14 @@ import fs from 'fs'
 import { spy } from 'sinon'
 import { file } from 'chai-files'
 import rimraf from 'rimraf'
-import noop from 'lodash/noop'
 
 const TEMP_ASSETS_DIRECTORY = `${__dirname}/.tmp`
 
 describe('attachment', () => {
   const veemSDK = new VeemSDK(CONFIG)
 
-  beforeAll(async () => {
-    await fs.mkdir(TEMP_ASSETS_DIRECTORY, { recursive: true }, noop)
+  beforeAll(() => {
+    fs.mkdirSync(TEMP_ASSETS_DIRECTORY, { recursive: true })
   })
 
   afterAll(() => {


### PR DESCRIPTION
**Description**
Fixes error thrown in `E2E` tests for the Attachment model tests.

**Notes**
Third argument, callback, is required on `fs.mkdir`.