### PR TITLE
Upgrades lint-staged Package to ^8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2625,15 +2625,14 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
       }
     },
@@ -3654,12 +3653,6 @@
           }
         }
       }
-    },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -6630,9 +6623,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -6803,19 +6796,18 @@
       }
     },
     "lint-staged": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.5.tgz",
-      "integrity": "sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.0.tgz",
+      "integrity": "sha512-DxguyxGOIfb67wZ6EOrqzjAbw6ZH9XK3YS74HO+erJf6+SAQeJJPN//GBOG5xhdt2THeuXjVPaHcCYOWGZwRbA==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
         "commander": "^2.14.1",
-        "cosmiconfig": "^5.0.2",
+        "cosmiconfig": "^5.2.0",
         "debug": "^3.1.0",
         "dedent": "^0.7.0",
         "del": "^3.0.0",
         "execa": "^1.0.0",
-        "find-parent-dir": "^0.3.0",
         "g-status": "^2.0.2",
         "is-glob": "^4.0.0",
         "is-windows": "^1.0.2",
@@ -6832,7 +6824,7 @@
         "staged-git-files": "1.1.2",
         "string-argv": "^0.0.2",
         "stringify-object": "^3.2.2",
-        "yup": "^0.26.10"
+        "yup": "^0.27.0"
       },
       "dependencies": {
         "debug": {
@@ -6864,9 +6856,9 @@
       },
       "dependencies": {
         "p-map": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-          "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
           "dev": true
         }
       }
@@ -6993,12 +6985,6 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8617,9 +8603,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -8765,9 +8751,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.107.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.107.0.tgz",
-      "integrity": "sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==",
+      "version": "1.113.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
+      "integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -9265,9 +9251,9 @@
       "dev": true
     },
     "synchronous-promise": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.6.tgz",
-      "integrity": "sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
+      "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
     "term-size": {
@@ -9344,7 +9330,7 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1",
-        "superagent": "^5.0.2"
+        "superagent": "^5.0.6"
       },
       "dependencies": {
         "component-emitter": {
@@ -10203,28 +10189,17 @@
       }
     },
     "yup": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
-      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
+      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.0.0",
+        "@babel/runtime": "^7.0.0",
         "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
+        "synchronous-promise": "^2.0.6",
         "toposort": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-          "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "husky": "^2.4.0",
     "jest": "^24.8.0",
     "jest-circus": "^24.7.0",
-    "lint-staged": "^8.1.5",
+    "lint-staged": "^8.2.0",
     "moment": "^2.24.0",
     "nock": "^10.0.6",
     "nodemon": "^1.18.10",


### PR DESCRIPTION
**Description**
Upgrades `lint-staged` package to `^8.2.0` in order to `js-yaml` dependency to `>=3.13.1`, in order to resolve security vulnerability.